### PR TITLE
Remove @OnlyIn annotation from cardboard armor

### DIFF
--- a/src/main/java/blueduck/dustrial/dustrialdecor/items/CardboardArmorMaterial.java
+++ b/src/main/java/blueduck/dustrial/dustrialdecor/items/CardboardArmorMaterial.java
@@ -37,7 +37,6 @@ public class CardboardArmorMaterial implements ArmorMaterial {
         return Ingredient.of(DustrialBlocks.CARDBOARD.get());
     }
 
-    @OnlyIn(Dist.CLIENT)
     @Override
     public String getName() {
         return "dustrial_decor:cardboard";


### PR DESCRIPTION
Caused server-side crash when used by another mod:
[crash-2022-08-22_15.14.18-server.txt](https://github.com/BlueDuckYT/DustrialDecor/files/9394823/crash-2022-08-22_15.14.18-server.txt)

Do not use `@OnlyIn`, see [Forge documentation](https://docs.minecraftforge.net/en/1.18.x/concepts/sides/#fmlenvironmentdist-and-onlyin).

I did not test this, but I'm highly confident that this is the problem, going off of the crash log.